### PR TITLE
Case when DevelopmentRoomId wasn't populated the contains call was st…

### DIFF
--- a/CoreCodedChatbot/Services/ChatbotService.cs
+++ b/CoreCodedChatbot/Services/ChatbotService.cs
@@ -124,7 +124,7 @@ namespace CoreCodedChatbot.Services
             try
             {
                 if ((config.DevelopmentBuild && !e.Command.ChatMessage.Channel.Contains(DevelopmentRoomId)) ||
-                     (!config.DevelopmentBuild && e.Command.ChatMessage.Channel.Contains(DevelopmentRoomId)))
+                     (!config.DevelopmentBuild && e.Command.ChatMessage.Channel.Contains(DevelopmentRoomId) && !string.IsNullOrWhiteSpace(DevelopmentRoomId)))
                     return;
 
                 if (config.DevelopmentBuild && !client.JoinedChannels.Select(jc => jc.Channel)


### PR DESCRIPTION
…ill matching.